### PR TITLE
fix: typo

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -40,7 +40,7 @@ pub fn unwrap_list_nest(ast: Expr) -> Vec<Expr> {
         _ => {
             // This probably will not happen because everything is wrapped
             // in list. So it would be impossible that the ast is not a list.
-            eprintln!("Possibly a bug in the compiler, you shouln't get this messages.");
+            eprintln!("Possibly a bug in the compiler, you shouln't get this message.");
             dbg!(ast);
         }
     };


### PR DESCRIPTION
## fix: typo

I do not need to elaborate, the commit only consists of one little change that you can easily figure out of from code.